### PR TITLE
Update README to specify relative path for manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ export default defineConfig({
 });
 ```
 
-Link your manifest in `index.html`:
+Link your manifest in `index.html` ensuring href uses a relative path, not an absolute one:
 
 ```html
-<link rel="manifest" href="/manifest.webmanifest" />
+<link rel="manifest" href="./manifest.webmanifest" />
 ```
 
 ## Configuration


### PR DESCRIPTION
Closes #24 

Updates README.md to specify that href should be a relative path to your manifest—not an absolute one.

Thank you for the plugin, @budarin! Tweaking the path to be relative fixed my issues.